### PR TITLE
Center the fullPageAtForm properly

### DIFF
--- a/lib/full_page_at_form.html
+++ b/lib/full_page_at_form.html
@@ -1,7 +1,7 @@
 <template name="fullPageAtForm">
   <div class="container">
     <div class="row">
-      <div class="col-md-5 col-md-offset-3">
+      <div class="col-md-6 col-md-offset-3">
         {{> atForm}}
       </div>
     </div>


### PR DESCRIPTION
The `fullPageAtForm` template should be using an even numbered column in order to be properly centered on the screen:

Example `col-md-5`:
![screen shot 2014-10-24 at 1 30 27 pm](https://cloud.githubusercontent.com/assets/3907/4775943/f738ff36-5bbc-11e4-9c19-70762fd530a4.png)

VS. `col-md-6`
![screen shot 2014-10-24 at 1 30 38 pm](https://cloud.githubusercontent.com/assets/3907/4775946/0440c40c-5bbd-11e4-8e9e-2fa97c020acf.png)
