### PR TITLE
Added dependency fontawesome package

### DIFF
--- a/package.js
+++ b/package.js
@@ -9,6 +9,7 @@ Package.on_use(function(api, where) {
   api.versionsFrom('METEOR@1.0');
 
   api.use([
+    'fortawesome:fontawesome@4.3.0',
     'less',
     'templating',
   ], 'client');


### PR DESCRIPTION
When the login form is used without installing the fontawesome package, the social media icons (FB, twitter etc.) don't show up. I was able to resolve this in my environment by adding the fontawesome package. I believe this package should be included as one of the dependencies.