### PR TITLE
Make it work with Bootstrap 4 grid

### DIFF
--- a/lib/full_page_at_form.html
+++ b/lib/full_page_at_form.html
@@ -1,7 +1,7 @@
 <template name="fullPageAtForm">
   <div class="container">
     <div class="row">
-      <div class="col-md-6 col-md-offset-3">
+      <div class="col-md-6 col-md-offset-3 offset-md-3">
         {{> atForm}}
       </div>
     </div>


### PR DESCRIPTION
The offset class in bootstrap 4 is just 'offset-number' now. 

https://getbootstrap.com/docs/4.0/layout/grid/#offset-classes